### PR TITLE
adding event description into ical

### DIFF
--- a/add2cal/add2cal.py
+++ b/add2cal/add2cal.py
@@ -117,6 +117,7 @@ class Add2Cal():
         e = Event()
         e.alarms = [DisplayAlarm(trigger=self.trigger_datetime)]
         e.name = self.event_title
+        e.description = self.event_description
         e.begin = self.start_datetime
         e.end = self.end_datetime
         c.events.add(e)

--- a/add2cal/add2cal.py
+++ b/add2cal/add2cal.py
@@ -118,6 +118,7 @@ class Add2Cal():
         e.alarms = [DisplayAlarm(trigger=self.trigger_datetime)]
         e.name = self.event_title
         e.description = self.event_description
+        e.location = self.event_location
         e.begin = self.start_datetime
         e.end = self.end_datetime
         c.events.add(e)

--- a/add2cal/tests/test_add2cal.py
+++ b/add2cal/tests/test_add2cal.py
@@ -9,6 +9,7 @@ DATE_FORMAT = "%Y%m%dT%H%M%S"
 
 EXPECTED_CONTENT = "BEGIN:VCALENDAR"
 DESCRIPTION_CONTENT = 'DESCRIPTION:this is an exciting event'
+LOCATION_CONTENT = 'LOCATION:narnia'
 
 
 class TestAdd2Cal(unittest.TestCase):
@@ -62,7 +63,7 @@ class TestAdd2Cal(unittest.TestCase):
             content
         )
 
-    def test_ical_content_contains_description(self):
+    def test_ical_content_contains_description_and_location(self):
         self.maxDiff = None
         self.add2cal.start_datetime = arrow.get(datetime.now())
         self.add2cal.end_datetime = arrow.get(datetime.now())
@@ -70,7 +71,6 @@ class TestAdd2Cal(unittest.TestCase):
         start = datetime.now().astimezone(tz).strftime(DATE_FORMAT)
         self.add2cal.trigger_datetime = datetime.strptime(start, DATE_FORMAT)
         content = self.add2cal.ical_content()
-        self.assertIn(
-            DESCRIPTION_CONTENT,
-            content
-        )
+        for elem in [LOCATION_CONTENT, DESCRIPTION_CONTENT]:
+            self.assertIn(elem, content)
+

--- a/add2cal/tests/test_add2cal.py
+++ b/add2cal/tests/test_add2cal.py
@@ -8,6 +8,7 @@ from pytz import timezone
 DATE_FORMAT = "%Y%m%dT%H%M%S"
 
 EXPECTED_CONTENT = "BEGIN:VCALENDAR"
+DESCRIPTION_CONTENT = 'DESCRIPTION:this is an exciting event'
 
 
 class TestAdd2Cal(unittest.TestCase):
@@ -58,5 +59,18 @@ class TestAdd2Cal(unittest.TestCase):
         content = self.add2cal.ical_content()
         self.assertIn(
             EXPECTED_CONTENT,
+            content
+        )
+
+    def test_ical_content_contains_description(self):
+        self.maxDiff = None
+        self.add2cal.start_datetime = arrow.get(datetime.now())
+        self.add2cal.end_datetime = arrow.get(datetime.now())
+        tz = timezone(self.timezone)
+        start = datetime.now().astimezone(tz).strftime(DATE_FORMAT)
+        self.add2cal.trigger_datetime = datetime.strptime(start, DATE_FORMAT)
+        content = self.add2cal.ical_content()
+        self.assertIn(
+            DESCRIPTION_CONTENT,
             content
         )


### PR DESCRIPTION
This PR adds an event description field to the ics file contents.

The current way of testing this (outside of the automated test) would be to print the ical contents [here](https://github.com/masschallenge/add2cal/compare/AC-7924?expand=1#diff-763ae2dbaa25b80034680f8288c4a185R72) and then put those contents in a <filename>.ics and email it to yourself.