### PR TITLE
[AC-7984] Fix outlook calendar url output

### DIFF
--- a/add2cal/add2cal.py
+++ b/add2cal/add2cal.py
@@ -1,9 +1,12 @@
-from urllib import parse
-from ics import Calendar, Event
-from ics import DisplayAlarm
-import hashlib
-import datetime
+from datetime import datetime
+from hashlib import md5
+from ics import (
+    Calendar,
+    DisplayAlarm,    
+    Event,
+)
 import re
+from urllib import parse
 
 
 BASE_URLS = {
@@ -11,8 +14,10 @@ BASE_URLS = {
     'outlook': 'https://outlook.office.com/owa/',
     'yahoo': 'http://calendar.yahoo.com'
 }
-DATE_FORMAT = "%Y%m%dT%H%M%S"
 
+INPUT_DATE_FORMAT = "%Y%m%dT%H%M%S"
+OUTLOOK_DATE_FORMAT = '%Y-%m-%dT%I:%M:%SZ'
+TRIGGER_DATE_FORMAT = '%Y-%m-%dT%I:%M'
 
 def _build_url(baseurl, args_dict):
     url_parts = list(parse.urlparse(baseurl))
@@ -37,8 +42,8 @@ class Add2Cal():
         self.event_location = location
         self.timezone = timezone
         self.event_description = description
-        self.trigger_datetime = datetime.datetime.strptime(
-            start, DATE_FORMAT).strftime('%Y-%m-%dT%I:%M')
+        self.trigger_datetime = datetime.strptime(
+            start, INPUT_DATE_FORMAT).strftime(TRIGGER_DATE_FORMAT)
         self.event_uid = self._get_uid([
             start,
             end,
@@ -48,7 +53,7 @@ class Add2Cal():
             self.timezone])
 
     def _get_uid(self, params):
-        param_hash = hashlib.md5(str(params).encode('utf-8'))
+        param_hash = md5(str(params).encode('utf-8'))
         return param_hash.hexdigest()
 
     def google_calendar_url(self):
@@ -73,8 +78,8 @@ class Add2Cal():
         return _build_url(BASE_URLS['google'], params)
 
     def yahoo_calendar_url(self):
-        end = datetime.datetime.strptime(self.end_datetime, DATE_FORMAT)
-        start = datetime.datetime.strptime(self.start_datetime, DATE_FORMAT)
+        end = datetime.strptime(self.end_datetime, INPUT_DATE_FORMAT)
+        start = datetime.strptime(self.start_datetime, INPUT_DATE_FORMAT)
 
         duration_datetime = end - start
         duration_seconds = duration_datetime.seconds
@@ -97,13 +102,13 @@ class Add2Cal():
         return _build_url(BASE_URLS['yahoo'], params)
 
     def outlook_calendar_url(self):
-        end = datetime.datetime.strptime(self.end_datetime, DATE_FORMAT)
-        start = datetime.datetime.strptime(self.start_datetime, DATE_FORMAT)
+        end = datetime.strptime(self.end_datetime, INPUT_DATE_FORMAT)
+        start = datetime.strptime(self.start_datetime, INPUT_DATE_FORMAT)
 
         params = {
             'path': '/calendar/action/compose',
-            'startdt': start.strftime('%Y%m%dT%I%M%S'),
-            'enddt': end.strftime('%Y%m%dT%I%M%S'),
+            'startdt': start.strftime(OUTLOOK_DATE_FORMAT),
+            'enddt': end.strftime(OUTLOOK_DATE_FORMAT),
             'subject': self.event_title,
             'uid': self.event_uid,
             'location': self.event_location,


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7984

This fixes the issue described in the ticket. To test, start up a python shell and import Add2Cal. Create an Add2Cal event with start and end times in UTC, and check that the resulting `outlook_calendar_url()` creates an correct entry in your outlook calendar, relative to your local timezone. 

For example, when I created an event as follows:

>>> from datetime import datetime, timedelta
>>> from pytz import utc, timezone
>>> from add2cal import Add2Cal
>>> title = "test title"
>>> description = "description"
>>> location = "somewhere over here"
>>> timezone = "America/New_York"
>>> date = utc.localize(datetime(2020, 8,7,3))
>>> from add2cal.add2cal import INPUT_DATE_FORMAT
>>> start = date.strftime(INPUT_DATE_FORMAT)
>>> end = (date + timedelta(minutes=30)).strftime(INPUT_DATE_FORMAT)
>>> a2c = Add2Cal(start=start, end=end, title=title, description=description, location=location, timezone=timezone)
>>> a2c.outlook_calendar_url() 
'https://outlook.office.com/owa/?path=%2Fcalendar%2Faction%2Fcompose&startdt=2020-08-07T03%3A00%3A00Z&enddt=2020-08-07T03%3A30%3A00Z&subject=test+title&uid=0b62daf3f476e6404b542831c8ccb14f&location=somewhere+over+here&body=description&allday='
```

I  got an event like this:


![Screen Shot 2020-08-04 at 5 38 20 PM](https://user-images.githubusercontent.com/5283553/89347734-51347280-d679-11ea-951b-ac5bc013d91b.png)


(notice that the four-hour difference between UTC and America/New_York caused the date to roll back to 8/6 - this was the intention in picking a 3AM UTC time!) 


Note: I have no idea what sort of test to write here since the core of this is really just fixing the output format for the date strings. If any reviewer has a suggestion of a test they'd like to see, I'd be happy to entertain those suggestions. 