### PR TITLE
AC-8040 add2cal does not include `pytz` in requirements/dependencies but it's needed for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 urllib3
 ics
+pytz
 

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
     package='add2cal',
     install_requires=[
         'urllib3',
-        'ics==v0.4'
+        'ics==v0.4',
+        'pytz'
     ])


### PR DESCRIPTION
### Changes introduced in [AC-8040](https://masschallenge.atlassian.net/browse/AC-8040)
- Add pytx to the requirements
### How to test
- Ensure add2cal declares pytz in its install_requires or setup.py or other appropriate location
- `python -m pytest` runs tests without errors

